### PR TITLE
fix: Remove pie chart from Analytics tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,6 @@ let state = {
 let charts = {
   main: null,
   yoy: null,
-  category: null,
   projection: null
 };
 
@@ -190,7 +189,6 @@ charts.main = new Chart(ctx, config);
 ### Chart Types
 - **Main Timeline**: Line/Bar/Area/Step (user-selectable)
 - **YoY Comparison**: Bar chart with color coding
-- **Category Breakdown**: Doughnut chart
 - **Projection**: Line chart with forecast scenarios
 
 ### Theme Integration

--- a/app.js
+++ b/app.js
@@ -34,7 +34,6 @@ import {
     updateYoyChartType,
     buildMainChart,
     buildYoyChart,
-    buildCategoryChart,
     buildProjectionChart,
     updateProjectionChartData
 } from './js/charts.js';
@@ -113,7 +112,6 @@ let state = {
 let charts = {
     main: null,
     yoy: null,
-    category: null,
     projection: null
 };
 
@@ -502,7 +500,7 @@ async function cycleNextScenario() {
     Object.values(charts).forEach(chart => {
         if (chart) chart.destroy();
     });
-    charts = { main: null, yoy: null, category: null, projection: null };
+    charts = { main: null, yoy: null, projection: null };
 
     // Load the new scenario
     await loadDemoData(state.currentScenarioIndex);
@@ -586,8 +584,8 @@ function resetDashboard() {
     Object.values(charts).forEach(chart => {
         if (chart) chart.destroy();
     });
-    charts = { main: null, yoy: null, category: null, projection: null };
-    
+    charts = { main: null, yoy: null, projection: null };
+
     // Reset state
     state.currentTab = 'home';
     employeeData = null;
@@ -857,7 +855,6 @@ function setTheme(theme) {
         // Instantly update chart colors without rebuilding (performance optimization)
         updateChartTheme(charts.main);
         updateChartTheme(charts.yoy);
-        updateChartTheme(charts.category);
         updateChartTheme(charts.projection);
     }
 }
@@ -1250,7 +1247,6 @@ function setTab(tabId, pushHistory = true) {
     if (tabId === 'analytics' && !charts.yoy) {
         setTimeout(() => {
             buildYoyChart();
-            buildCategoryChart();
         }, 100);
     }
     if (tabId === 'projections' && !charts.projection) {

--- a/index.html
+++ b/index.html
@@ -4233,14 +4233,6 @@ History
                         </div>
                     </div>
 
-                    <div class="chart-section">
-                        <div class="chart-header">
-                            <h2 class="chart-title">Adjustments by Category</h2>
-                        </div>
-                        <div class="chart-wrapper chart-wrapper-250">
-                            <canvas id="categoryChart"></canvas>
-                        </div>
-                    </div>
                 </div>
 
                 <!-- PROJECTIONS TAB -->

--- a/js/charts.js
+++ b/js/charts.js
@@ -196,13 +196,6 @@ export function updateChartTheme(chart) {
         chart.options.plugins.legend.labels.color = colors.text;
     }
 
-    // Update category chart border color
-    if (chart.config.type === 'doughnut') {
-        chart.data.datasets.forEach(dataset => {
-            dataset.borderColor = _state.theme === 'tactical' ? '#141416' : '#ffffff';
-        });
-    }
-
     // Fast update without animation
     chart.update('none');
 }
@@ -465,81 +458,6 @@ export function buildYoyChart() {
     } catch (error) {
         console.error('Failed to build YoY chart:', error);
         _showUserMessage('YoY chart rendering failed. Try refreshing the page.', 'error');
-    }
-}
-
-/**
- * Builds the category breakdown doughnut chart.
- *
- * Groups salary adjustments by reason (Merit, Promotion, Cost of Living, etc.)
- * and displays as a doughnut chart with percentage breakdown.
- * Excludes "New Hire" records as they represent starting point, not adjustments.
- *
- * @returns {void}
- */
-export function buildCategoryChart() {
-    const employeeData = _getEmployeeData();
-    if (!employeeData) return;
-
-    try {
-        const ctx = getChartContext('categoryChart', 'Category chart');
-        if (!ctx) return;
-
-        const colors = getThemeColors();
-
-        // Filter out "New Hire" - it's the starting point, not an adjustment
-        const adjustments = employeeData.records.filter(r => r.reason !== 'New Hire');
-
-        // Guard against no adjustments
-        if (adjustments.length === 0) return;
-
-        const categories = {};
-        adjustments.forEach(r => {
-            const reason = r.reason || 'Other';
-            if (reason !== CONSTANTS.EMPTY_REASON_PLACEHOLDER) {
-                categories[reason] = (categories[reason] || 0) + 1;
-            }
-        });
-
-        const labels = Object.keys(categories);
-        const data = Object.values(categories);
-
-        const categoryColors = [colors.line1, colors.line2,
-            _state.theme === 'tactical' ? '#4598d4' : '#7b2cbf',
-            _state.theme === 'tactical' ? '#d45745' : '#d00000'];
-
-        if (_charts.category) _charts.category.destroy();
-
-        _charts.category = new Chart(ctx, {
-            type: 'doughnut',
-            data: {
-                labels,
-                datasets: [{
-                    data,
-                    backgroundColor: categoryColors,
-                    borderColor: _state.theme === 'tactical' ? '#141416' : '#ffffff',
-                    borderWidth: 3
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                cutout: '60%',
-                plugins: {
-                    legend: {
-                        position: 'right',
-                        labels: {
-                            color: colors.text,
-                            padding: 20,
-                            font: { family: _state.theme === 'tactical' ? 'JetBrains Mono' : 'Space Grotesk', size: 12 }
-                        }
-                    }
-                }
-            }
-        });
-    } catch (error) {
-        console.error('Failed to build category chart:', error);
-        _showUserMessage('Category chart rendering failed. Try refreshing the page.', 'error');
     }
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -130,7 +130,7 @@ helpers/
 
 - ✅ All 7 tabs present and clickable
 - ✅ 6 KPI cards visible with values
-- ✅ 4 charts rendered (main, YoY, category, projection)
+- ✅ 3 charts rendered (main, YoY, projection)
 - ✅ History table populated with records
 - ✅ Initial state correct (Home tab active)
 

--- a/tests/e2e/02-dashboard-rendering.spec.js
+++ b/tests/e2e/02-dashboard-rendering.spec.js
@@ -4,7 +4,7 @@
  * Tests for:
  * - All 7 tabs present and clickable
  * - 6 KPI cards visible with values
- * - 4 main charts rendered (main, YoY, category, projection)
+ * - 3 main charts rendered (main, YoY, projection)
  * - History table populated with correct row count
  * - Initial state correct (Home tab active)
  */
@@ -45,7 +45,7 @@ test.describe('Dashboard Rendering', () => {
     await checkA11y(page);
   });
 
-  test('renders all 4 main charts', async ({ page }) => {
+  test('renders all 3 main charts', async ({ page }) => {
     // Verify main chart on Home tab
     await switchTab(page, 'home');
     await assertChartRendered(page, 'mainChart');
@@ -53,9 +53,6 @@ test.describe('Dashboard Rendering', () => {
     // Verify YoY chart on Analytics tab
     await switchTab(page, 'analytics');
     await assertChartRendered(page, 'yoyChart');
-
-    // Verify category chart on Analytics tab
-    await assertChartRendered(page, 'categoryChart');
 
     // Verify projection chart on Projections tab
     await switchTab(page, 'projections');


### PR DESCRIPTION
## Summary
- Removes the "Adjustments by Category" doughnut chart from the Analytics tab
- The chart added no meaningful insight and cluttered the interface

## Changes
- Removed HTML canvas element for categoryChart
- Removed `buildCategoryChart()` function from `js/charts.js`
- Removed doughnut-specific theme update code
- Removed import/call in `app.js`
- Updated tests to expect 3 charts instead of 4

## Related Issues
- Closes #115
- Obsoletes #90 (pie chart colors don't match badge colors)
- Obsoletes #91 (pie chart legend is too far away)

## Test Plan
- [ ] Analytics tab loads without errors
- [ ] YoY chart still renders correctly
- [ ] Theme switching works for all remaining charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)