### PR TITLE
feat: Landing page UX - Slider reset + copy improvements (#108, #111, #120)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1697,6 +1697,9 @@ function initEventListeners() {
     const tabIndicator = document.getElementById('tabIndicator');
     const browserUrl = document.getElementById('browserUrl');
 
+    // Get slider reference for reset on chip click (#108, #111)
+    const comparisonSliderRef = document.getElementById('comparisonSlider');
+
     featureChips.forEach(chip => {
         chip.addEventListener('click', () => {
             // Update active state
@@ -1718,6 +1721,11 @@ function initEventListeners() {
                     afterImg.src = data.img;
                     afterImg.style.opacity = '1';
                 }, 150);
+
+                // Reset slider to show full "after" view (#108, #111)
+                if (comparisonSliderRef) {
+                    comparisonSliderRef.value = 0;
+                }
             }
         });
     });

--- a/index.html
+++ b/index.html
@@ -3805,28 +3805,28 @@
                         <span class="chip-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M16 7h6v6"/><path d="m22 7l-8.5 8.5l-5-5L2 17"/></g></svg></span>
                         <div class="chip-content">
                             <span class="chip-title">Salary Timeline</span>
-                            <span class="chip-desc">Interactive compensation chart</span>
+                            <span class="chip-desc">See every raise in context</span>
                         </div>
                     </button>
                     <button class="feature-chip" data-tab="market">
                         <span class="chip-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></g></svg></span>
                         <div class="chip-content">
                             <span class="chip-title">Market Benchmarks</span>
-                            <span class="chip-desc">Compare to industry standards</span>
+                            <span class="chip-desc">Know if you're paid fairly</span>
                         </div>
                     </button>
                     <button class="feature-chip" data-tab="analytics">
                         <span class="chip-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3v16a2 2 0 0 0 2 2h16M7 11h8m-8 5h12M7 6h3"/></svg></span>
                         <div class="chip-content">
                             <span class="chip-title">Growth Analytics</span>
-                            <span class="chip-desc">CAGR and inflation-adjusted</span>
+                            <span class="chip-desc">Track real purchasing power</span>
                         </div>
                     </button>
                     <button class="feature-chip" data-tab="projections">
                         <span class="chip-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275zM5 3v4m14 14v-4M3 5h4m14 14h-4"/></svg></span>
                         <div class="chip-content">
                             <span class="chip-title">Future Projections</span>
-                            <span class="chip-desc">5-10 year forecasts</span>
+                            <span class="chip-desc">Plan your financial future</span>
                         </div>
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- Auto-reset comparison slider when clicking feature preview buttons
- Updated preview card descriptions to focus on user value (WHY) instead of features (WHAT)

## Changes

### Slider Behavior (#108, #111)
When clicking any feature chip (Salary Timeline, Market Benchmarks, etc.), the comparison slider now automatically resets to 0% to fully reveal the "after" view.

### Preview Card Copy (#120)
| Before | After |
|--------|-------|
| Interactive compensation chart | See every raise in context |
| Compare to industry standards | Know if you're paid fairly |
| CAGR and inflation-adjusted | Track real purchasing power |
| 5-10 year forecasts | Plan your financial future |

## Test plan
- [ ] Click each feature chip and verify slider resets to show full dashboard view
- [ ] Verify new descriptions are visible on landing page
- [ ] Test that slider still works manually after auto-reset

Closes #108
Closes #111
Closes #120

🤖 Generated with [Claude Code](https://claude.ai/code)