### PR TITLE
feat: Demo & modal UX - Subtle banner + auto-close (#104, #66)

### DIFF
--- a/app.js
+++ b/app.js
@@ -521,7 +521,7 @@ function updateScenarioLabel() {
 function loadJsonFile(event) {
     const file = event.target.files[0];
     if (!file) return;
-    
+
     const reader = new FileReader();
     reader.onload = function(e) {
         try {
@@ -535,6 +535,12 @@ function loadJsonFile(event) {
             document.getElementById('demoBanner').classList.add('hidden');
             // Update URL (removes demo flag)
             updateUrlParams();
+            // Auto-close import modal after successful load (#66)
+            const modal = document.getElementById('importModal');
+            if (modal) {
+                modal.classList.remove('visible');
+                document.body.style.overflow = '';
+            }
         } catch (err) {
             showUserMessage('Error loading file: ' + err.message, 'error');
         }

--- a/index.html
+++ b/index.html
@@ -1507,11 +1507,11 @@
             align-items: center;
             justify-content: center;
             gap: var(--space-3);
-            padding: var(--space-2) var(--space-4);
-            background: var(--bg-tertiary);
-            border-bottom: 1px solid var(--border-color);
-            color: var(--text-secondary);
-            font-size: var(--font-size-sm);
+            padding: var(--space-1) var(--space-4);
+            background: var(--color-warning-muted);
+            border-bottom: 1px solid color-mix(in srgb, var(--color-warning) 30%, transparent);
+            color: var(--text-primary);
+            font-size: var(--font-size-xs);
             position: sticky;
             top: 0;
             z-index: 200;
@@ -1529,9 +1529,9 @@
         }
 
         .demo-banner-icon svg {
-            width: 1rem;
-            height: 1rem;
-            color: var(--color-info);
+            width: 0.875rem;
+            height: 0.875rem;
+            color: var(--color-warning);
         }
 
         .demo-banner-text {
@@ -1539,8 +1539,8 @@
         }
 
         .demo-banner-text strong {
-            font-weight: 700;
-            color: var(--color-info);
+            font-weight: 600;
+            color: var(--text-primary);
         }
 
         .demo-banner-close {


### PR DESCRIPTION
## Summary
- Make demo banner less visually aggressive
- Auto-close import modal after successful JSON file load

## Changes

### Demo Banner (#104)
- **Background**: Changed from `--bg-tertiary` to `--color-warning-muted` (subtle amber)
- **Font size**: Reduced from `--font-size-sm` to `--font-size-xs`
- **Padding**: Reduced from `var(--space-2)` to `var(--space-1)`
- **Border**: Subtle amber tint instead of standard border
- **Icon**: Smaller (0.875rem) with amber color
- **Text**: Dark primary color instead of bright info blue

### Import Modal (#66)
After successful JSON file load, modal now auto-closes instead of requiring manual dismissal.

## Test plan
- [ ] Load demo mode and verify banner is less visually prominent
- [ ] Test in both light and dark themes
- [ ] Import a JSON file and verify modal closes automatically
- [ ] Verify error states still show (invalid JSON should NOT close modal)

Closes #104
Closes #66

🤖 Generated with [Claude Code](https://claude.ai/code)