### PR TITLE
fix: Address Phase 7 feedback

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,8 +21,7 @@ import {
     getBenchmarkComparisons,
     calculateAverageMonthsBetweenDates,
     formatDateSummary,
-    formatDateDetail,
-    formatDateProse
+    formatDateDetail
 } from './js/calculations.js';
 import {
     validateSalaryRange,
@@ -472,6 +471,14 @@ async function loadDemoData(scenarioIndex = null) {
         state.currentScenarioIndex = scenarioIndex;
     }
 
+    // #79 fix: Preserve tab from URL before it gets overwritten
+    const params = new URLSearchParams(window.location.search);
+    const initialTab = params.get('tab');
+    const validTabs = ['home', 'story', 'market', 'history', 'analytics', 'projections', 'help'];
+    if (initialTab && validTabs.includes(initialTab)) {
+        state.currentTab = initialTab;
+    }
+
     const scenario = DEMO_SCENARIOS[scenarioIndex];
 
     employeeData = {
@@ -486,12 +493,12 @@ async function loadDemoData(scenarioIndex = null) {
     await loadChartJS();
 
     showDashboard();
-    
+
     // Update demo banner
     document.getElementById('demoBanner').classList.remove('hidden');
     updateScenarioLabel();
-    
-    // Update URL
+
+    // Update URL (now preserves the tab since state.currentTab was set above)
     updateUrlParams();
 }
 
@@ -576,7 +583,11 @@ function showDashboard() {
     document.getElementById('dashboardPage').classList.remove('hidden');
     window.scrollTo(0, 0);
     initDashboard();
-    checkInitialHash(); // Check URL hash for tab navigation
+
+    // If a non-home tab was specified (e.g., from URL), switch to it immediately
+    if (state.currentTab && state.currentTab !== 'home') {
+        setTab(state.currentTab, false);
+    }
 
     // Focus management for accessibility - move focus to dashboard heading
     setTimeout(() => {
@@ -974,7 +985,7 @@ function updateStory() {
     const dollarIncrease = current - start;
     
     const data = {
-        hireDateFormatted: formatDateProse(employeeData.hireDate),
+        hireDateFormatted: formatDateDetail(employeeData.hireDate),
         startSalary: state.showDollars ? formatCurrency(start) : 'Index 100',
         currentSalary: state.showDollars ? formatCurrency(current) : `Index ${formatCurrency(current, false)}`,
         dollarIncrease: state.showDollars ? formatCurrency(dollarIncrease) : `Index ${(dollarIncrease / start * 100).toFixed(0)}`,

--- a/index.html
+++ b/index.html
@@ -4128,7 +4128,6 @@ History
                 <div class="chart-wrapper">
                     <div class="chart-controls chart-controls-inline">
                         <button class="chart-type-btn active" data-chart="line">Line</button>
-                        <button class="chart-type-btn" data-chart="area">Area</button>
                         <button class="chart-type-btn" data-chart="bar">Bar</button>
                         <button class="chart-type-btn" data-chart="step">Step</button>
                     </div>

--- a/js/calculations.js
+++ b/js/calculations.js
@@ -324,48 +324,48 @@ export function calculateAverageMonthsBetweenDates(records, defaultValue = 12) {
 // ========================================
 
 /**
- * Formats a date for summary display (month + year only).
- * Use for KPIs, milestones, charts, and high-level summaries.
+ * Formats a date for summary display (full month + year).
+ * Use for KPIs, milestones, and high-level summaries.
  *
  * @param {string|Date} date - Date string or Date object
- * @returns {string} Formatted date like "Jan 2023"
+ * @returns {string} Formatted date like "January 2023"
  *
  * @example
- * formatDateSummary('2023-01-15'); // "Jan 2023"
- * formatDateSummary(new Date(2023, 0, 15)); // "Jan 2023"
+ * formatDateSummary('2023-01-15'); // "January 2023"
+ * formatDateSummary(new Date(2023, 0, 15)); // "January 2023"
  */
 export function formatDateSummary(date) {
     const d = typeof date === 'string' ? new Date(date) : date;
-    return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+    return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
 }
 
 /**
- * Formats a date for detailed display (month + day + year).
+ * Formats a date for detailed display (full month + day + year).
  * Use for history tables and detailed records.
- *
- * @param {string|Date} date - Date string or Date object
- * @returns {string} Formatted date like "Jan 15, 2023"
- *
- * @example
- * formatDateDetail('2023-01-15'); // "Jan 15, 2023"
- * formatDateDetail(new Date(2023, 0, 15)); // "Jan 15, 2023"
- */
-export function formatDateDetail(date) {
-    const d = typeof date === 'string' ? new Date(date) : date;
-    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-}
-
-/**
- * Formats a date for prose/narrative display (full month + day + year).
- * Use for story text and long-form content.
  *
  * @param {string|Date} date - Date string or Date object
  * @returns {string} Formatted date like "January 15, 2023"
  *
  * @example
- * formatDateProse('2023-01-15'); // "January 15, 2023"
+ * formatDateDetail('2023-01-15'); // "January 15, 2023"
+ * formatDateDetail(new Date(2023, 0, 15)); // "January 15, 2023"
  */
-export function formatDateProse(date) {
+export function formatDateDetail(date) {
     const d = typeof date === 'string' ? new Date(date) : date;
     return d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+/**
+ * Formats a date for compact display (short month + year).
+ * Use for charts and space-constrained contexts.
+ *
+ * @param {string|Date} date - Date string or Date object
+ * @returns {string} Formatted date like "Jan 2023"
+ *
+ * @example
+ * formatDateCompact('2023-01-15'); // "Jan 2023"
+ */
+export function formatDateCompact(date) {
+    const d = typeof date === 'string' ? new Date(date) : date;
+    return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
 }

--- a/js/charts.js
+++ b/js/charts.js
@@ -5,7 +5,7 @@
 /* global Chart */
 
 import { CONSTANTS } from './constants.js';
-import { calculateCAGR, getCurrentSalary, getStartingSalary, formatDateSummary } from './calculations.js';
+import { calculateCAGR, getCurrentSalary, getStartingSalary, formatDateCompact } from './calculations.js';
 
 // ========================================
 // MODULE STATE (injected via initCharts)
@@ -302,7 +302,7 @@ export function buildMainChart() {
 
         const data = [...employeeData.records].reverse();
 
-        const labels = data.map(r => formatDateSummary(r.date));
+        const labels = data.map(r => formatDateCompact(r.date));
 
         const values = data.map(r => _state.showDollars ? r.annual : (r.annual / getStartingSalary(employeeData)) * 100);
 


### PR DESCRIPTION
## Summary
Addresses feedback on Phase 7 PR (#131):

- **#72**: Remove Area chart type (pointless/redundant)
- **#86**: Use full month names ("January 2023" instead of "Jan 2023")
- **#79**: Fix tab persistence bug - Market tab now stays on refresh
- **#87**: Analytics hover should now work (CSS was correct, needed PR merge)

## Changes

### Chart Controls
- Removed "Area" button from main chart - only Line/Bar/Step remain

### Date Formatting
- `formatDateSummary()` now returns "January 2023" (full month)
- `formatDateDetail()` now returns "January 15, 2023" (full month + day)
- Added `formatDateCompact()` for charts: "Jan 2023" (space-constrained)

### Tab Persistence Bug Fix
The bug: refreshing on Market tab would reset to Home tab.

Root cause: `loadDemoData()` called `updateUrlParams()` before the tab from URL was applied, overwriting the `tab` parameter.

Fix:
1. Preserve initial tab from URL before it gets overwritten
2. Call `setTab()` immediately in `showDashboard()` for non-home tabs

## Test plan
- [ ] Refresh on Market tab → should stay on Market tab
- [ ] Dates show full month names (January, February, etc.)
- [ ] Chart has only Line/Bar/Step buttons (no Area)
- [ ] Analytics cards have hover animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)